### PR TITLE
Use different start_idx for matches and non matches.

### DIFF
--- a/abbreviations/utils.py
+++ b/abbreviations/utils.py
@@ -76,8 +76,9 @@ def replace(text, abb, fullterm):
                 w_start = start_idx + match.start()
                 w_end = w_start+len(match.group(1))
                 text = text[:w_start] + fullterm + text[w_end:]
-
-            start_idx += match.end()
+                start_idx = w_end + len(fullterm)
+            else:
+                start_idx += match.end()
     return text
 
 


### PR DESCRIPTION
When utils.replace loops through the words in the text, it either finds
the abbreviation or it doesn’t.  If it doesn’t find the abbreviation,
the next step should look after the end of the checked word. If it does
find the abbreviation, the next step should look after the length of
the full term that was sandwiched in there. That’s the key here, I
think.